### PR TITLE
ngs-validate-interp now can accept HML files for the expected and observed.

### DIFF
--- a/tools/src/main/java/org/nmdp/ngs/tools/ValidateInterpretation.java
+++ b/tools/src/main/java/org/nmdp/ngs/tools/ValidateInterpretation.java
@@ -24,7 +24,6 @@ package org.nmdp.ngs.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-
 import static org.dishevelled.compress.Readers.reader;
 import static org.dishevelled.compress.Writers.writer;
 
@@ -32,14 +31,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.concurrent.Callable;
 
 import com.google.common.base.Splitter;
-
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -49,9 +45,15 @@ import org.dishevelled.commandline.CommandLineParseException;
 import org.dishevelled.commandline.CommandLineParser;
 import org.dishevelled.commandline.Switch;
 import org.dishevelled.commandline.Usage;
-
 import org.dishevelled.commandline.argument.FileArgument;
 import org.dishevelled.commandline.argument.IntegerArgument;
+import org.nmdp.ngs.hml.HmlReader;
+import org.nmdp.ngs.hml.jaxb.AlleleAssignment;
+import org.nmdp.ngs.hml.jaxb.Glstring;
+import org.nmdp.ngs.hml.jaxb.Haploid;
+import org.nmdp.ngs.hml.jaxb.Hml;
+import org.nmdp.ngs.hml.jaxb.Sample;
+import org.nmdp.ngs.hml.jaxb.Typing;
 
 /**
  * Validate interpretation.
@@ -60,10 +62,12 @@ public final class ValidateInterpretation implements Callable<Integer> {
     private final File expectedFile;
     private final File observedFile;
     private final File outputFile;
+    private static boolean HaploidBoolean;
+    private static boolean GlstringBoolean;    
     private final int resolution;
     private final boolean printSummary;
     static final int DEFAULT_RESOLUTION = 2;
-    private static final String USAGE = "ngs-validate-interpretation -e expected.txt -b observed.txt [args]";
+    private static final String USAGE = "ngs-validate-interpretation -e expected.txt -b observed.txt -g -l [args]";
 
 
     /**
@@ -74,8 +78,10 @@ public final class ValidateInterpretation implements Callable<Integer> {
      * @param outputFile output file, if any
      * @param resolution minimum fields of resolution, must be in the range [1..4]
      * @param printSummary print summary report
+     * @param HaploidBoolean flag to use Haploid object from the HML
+     * @param GlstringBoolean flag to use Glstring object from the HML
      */
-    public ValidateInterpretation(final File expectedFile, final File observedFile, final File outputFile, final int resolution, final boolean printSummary) {
+    public ValidateInterpretation(final File expectedFile, final File observedFile, boolean HaploidBoolean, boolean GlstringBoolean, final File outputFile, final int resolution, final boolean printSummary) {
         checkNotNull(expectedFile);
         checkNotNull(observedFile);
         checkArgument(resolution > 0 && resolution < 5, "resolution must be in the range [1..4]");
@@ -84,6 +90,8 @@ public final class ValidateInterpretation implements Callable<Integer> {
         this.outputFile = outputFile;
         this.resolution = resolution;
         this.printSummary = printSummary;
+        ValidateInterpretation.HaploidBoolean  = HaploidBoolean;
+        ValidateInterpretation.GlstringBoolean = GlstringBoolean;         
     }
 
 
@@ -150,78 +158,151 @@ public final class ValidateInterpretation implements Callable<Integer> {
     static ListMultimap<String, String> readExpected(final File expectedFile) throws IOException {
         BufferedReader reader = null;
         ListMultimap<String, String> expected = ArrayListMultimap.create();
-        try {
-            reader = reader(expectedFile);
+        
+        if(isHML(expectedFile)){
+        	reader = reader(expectedFile);
+            Hml hml = HmlReader.read(reader);
+            for (Sample sample : hml.getSample()) {
+                String id = sample.getId();
+                for (Typing typing : sample.getTyping()) {
+                   for (AlleleAssignment alleleAssignment : typing.getAlleleAssignment()) {
+                	   List<Haploid> HapList = new ArrayList<Haploid>();
+                	   for (Object glstring : alleleAssignment.getPropertyAndHaploidAndGenotypeList()){
+                          String classType  = glstring.getClass().toString();
+                          String objectType = classType.substring(classType.indexOf("jaxb.") + 5,classType.length());
+                		   
+                          if(objectType.equals("Haploid") && HaploidBoolean){
+                              Haploid hap = (Haploid)glstring;
+                              HapList.add(hap);
+                              
+                          }else if(objectType.equals("Glstring") && GlstringBoolean){
+	                       	  Glstring gl = (Glstring)glstring;
+	                          List<String> Alleles = Splitter.onPattern("[+]+").splitToList(gl.getValue().replaceAll("[\n\r ]", ""));                         
+	                       	  expected.put(id, Alleles.get(0));
+	                       	  expected.put(id, Alleles.get(1));
+                          }          
+                          
+                	   }
+                	   
+                	   if(HaploidBoolean){
+                		   String hlaTyping1 = HapList.get(0).getLocus() + "*" +HapList.get(0).getType();
+                		   String hlaTyping2 = HapList.get(1).getLocus() + "*" +HapList.get(1).getType();
+                		   expected.put(id, hlaTyping1);
+                		   expected.put(id, hlaTyping2);
+                	   }               	   
 
-            int lineNumber = 1;
-            while (reader.ready()) {
-                String line = reader.readLine();
-                if (line == null) {
-                    break;
+                   }
                 }
-		
-                List<String> tokens = Splitter.onPattern("\\s+").splitToList(line);
-                if (tokens.size() != 6) {
-                    throw new IOException("invalid expected file format at line " + lineNumber);
-                }
-
-                String sample = tokens.get(0);
-                String locus = tokens.get(1);
-                String regionsFile = tokens.get(2);
-                String zygosity = tokens.get(3);
-                String firstAllele = tokens.get(4);
-                String secondAllele = tokens.get(5);
-
-                expected.put(sample, firstAllele);
-                expected.put(sample, secondAllele);
-
-                lineNumber++;
             }
-        }
-        finally {
-            try {
-                reader.close();
-            }
-            catch (Exception e) {
-                // ignore
-            }
+        }else{       
+	        try {
+	            reader = reader(expectedFile);
+	
+	            int lineNumber = 1;
+	            while (reader.ready()) {
+	                String line = reader.readLine();
+	                if (line == null) {
+	                    break;
+	                }
+			
+	                List<String> tokens = Splitter.onPattern("\\s+").splitToList(line);
+	                if (tokens.size() != 6) {
+	                    throw new IOException("invalid expected file format at line " + lineNumber);
+	                }
+	
+	                String sample = tokens.get(0);
+	                //String locus = tokens.get(1);
+	                //String regionsFile = tokens.get(2);
+	                //String zygosity = tokens.get(3);
+	                String firstAllele = tokens.get(4);
+	                String secondAllele = tokens.get(5);
+	
+	                expected.put(sample, firstAllele);
+	                expected.put(sample, secondAllele);
+	
+	                lineNumber++;
+	            }
+	        }
+	        finally {
+	            try {
+	                reader.close();
+	            }
+	            catch (Exception e) {
+	                // ignore
+	            }
+	        }
         }
         return expected;
     }
 
     static ListMultimap<String, String> readObserved(final File observedFile) throws IOException {
-        BufferedReader reader = null;
+       
         ListMultimap<String, String> observed = ArrayListMultimap.create();
-        try {
-            reader = reader(observedFile);
-
-            int lineNumber = 1;
-            while (reader.ready()) {
-                String line = reader.readLine();
-                if (line == null) {
-                    break;
+        BufferedReader reader = null;
+        if(isHML(observedFile)){
+        	reader = reader(observedFile);
+            Hml hml = HmlReader.read(reader);
+            for (Sample sample : hml.getSample()) {
+                String id = sample.getId();
+                for (Typing typing : sample.getTyping()) {
+                   for (AlleleAssignment alleleAssignment : typing.getAlleleAssignment()) {
+                	   List<Haploid> HapList = new ArrayList<Haploid>();
+                	   for (Object glstring : alleleAssignment.getPropertyAndHaploidAndGenotypeList()){
+                           String classType  = glstring.getClass().toString();
+                           String objectType = classType.substring(classType.indexOf("jaxb.") + 5,classType.length());
+                           
+                           if(objectType.equals("Haploid") && HaploidBoolean){
+                               Haploid hap = (Haploid)glstring;
+                               HapList.add(hap);
+                               
+                           }else if(objectType.equals("Glstring") && GlstringBoolean){
+                        	   Glstring gl = (Glstring)glstring;
+                        	   observed.put(id, gl.getValue().replaceAll("[\n\r ]", ""));
+                           }
+                		   
+                	   }
+                	   if(HaploidBoolean){
+                		   String hlaTyping1 = HapList.get(0).getLocus() + "*" +HapList.get(0).getType();
+                		   String hlaTyping2 = HapList.get(1).getLocus() + "*" +HapList.get(1).getType();
+                		   observed.put(id, hlaTyping1);
+                		   observed.put(id, hlaTyping2);
+                	   }
+                   }
                 }
-
-                List<String> tokens = Splitter.onPattern("\\s+").splitToList(line);
-                if (tokens.size() != 2) {
-                    throw new IOException("invalid observed file format at line " + lineNumber);
-                }
-
-                String sample = tokens.get(0);
-                String interpretation = tokens.get(1);
-
-                observed.put(sample, interpretation);
-
-                lineNumber++;
             }
-        }
-        finally {
-            try {
-                reader.close();
-            }
-            catch (Exception e) {
-                // ignore
-            }
+        }else{
+        	
+	        try {
+	        	reader = reader(observedFile);
+	        	
+	            int lineNumber = 1;
+	            while (reader.ready()) {
+	                String line = reader.readLine();
+	                if (line == null) {
+	                    break;
+	                }
+	
+	                List<String> tokens = Splitter.onPattern("\\s+").splitToList(line);
+	                if (tokens.size() != 2) {
+	                    throw new IOException("invalid observed file format at line " + lineNumber);
+	                }
+	
+	                String sample = tokens.get(0);
+	                String interpretation = tokens.get(1);
+	
+	                observed.put(sample, interpretation);
+	
+	                lineNumber++;
+	            }
+	        }
+	        finally {
+	            try {
+	                reader.close();
+	            }
+	            catch (Exception e) {
+	                // ignore
+	            }
+	        }
         }
         return observed;
     }
@@ -241,6 +322,17 @@ public final class ValidateInterpretation implements Callable<Integer> {
         return smallest;
     }
 
+    static boolean isHML(final File hmlFile) {
+    	String file = hmlFile.toString();
+        if(file.matches("(.+)\\.hml") || file.matches("(.+)\\.xml")){
+        	return true;
+        }else{
+        	return false;
+        }   
+    }
+    
+    
+    
     /**
      * Main.
      *
@@ -254,8 +346,11 @@ public final class ValidateInterpretation implements Callable<Integer> {
         FileArgument outputFile = new FileArgument("o", "output-file", "output file, default stdout", false);
         IntegerArgument resolution = new IntegerArgument("r", "resolution", "resolution, must be in the range [1..4], default " + DEFAULT_RESOLUTION, false);
         Switch printSummary = new Switch("s", "summary", "print summary");
-
-        ArgumentList arguments = new ArgumentList(about, help, expectedFile, observedFile, outputFile, resolution, printSummary);
+        Switch HaploidBoolean = new Switch("l", "haploid", "Flag for extracting Haploid data");        
+        Switch GlstringBoolean = new Switch("g", "glstring", "Flag for extracting Glstring data");  
+      
+        
+        ArgumentList arguments = new ArgumentList(about, help, expectedFile, observedFile, HaploidBoolean,  GlstringBoolean, outputFile, resolution, printSummary);
         CommandLine commandLine = new CommandLine(args);
 
         ValidateInterpretation validateInterpretation = null;
@@ -270,7 +365,7 @@ public final class ValidateInterpretation implements Callable<Integer> {
                 Usage.usage(USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
-            validateInterpretation = new ValidateInterpretation(expectedFile.getValue(), observedFile.getValue(), outputFile.getValue(), resolution.getValue(DEFAULT_RESOLUTION), printSummary.wasFound());
+            validateInterpretation = new ValidateInterpretation(expectedFile.getValue(), observedFile.getValue(), HaploidBoolean.wasFound(), GlstringBoolean.wasFound(), outputFile.getValue(), resolution.getValue(DEFAULT_RESOLUTION), printSummary.wasFound());
         }
         catch (CommandLineParseException e) {
             if (about.wasFound()) {
@@ -292,4 +387,6 @@ public final class ValidateInterpretation implements Callable<Integer> {
             System.exit(1);
         }
     }
+    
+    
 }

--- a/tools/src/test/java/org/nmdp/ngs/tools/ExtractExpectedTest.java
+++ b/tools/src/test/java/org/nmdp/ngs/tools/ExtractExpectedTest.java
@@ -37,6 +37,6 @@ public final class ExtractExpectedTest {
 	
 	@Test
 	public void testConstructor() {
-	    assertNotNull(new ExtractExpected(inputHmlFile));
+	    assertNotNull(new ExtractExpected(inputHmlFile,true,false));
 	}
 }

--- a/tools/src/test/java/org/nmdp/ngs/tools/ValidateInterpretationTest.java
+++ b/tools/src/test/java/org/nmdp/ngs/tools/ValidateInterpretationTest.java
@@ -51,12 +51,14 @@ public final class ValidateInterpretationTest {
     private File outputFile;
     private int resolution;
     private boolean printSummary;
-
+    private boolean HaploidBoolean;
+    private boolean GlstringBoolean;   
     @Before
     public void setUp() throws Exception {
         expectedFile = File.createTempFile("validateInterpretationTest", "txt");
         observedFile = File.createTempFile("validateInterpretationTest", "txt");
         resolution = ValidateInterpretation.DEFAULT_RESOLUTION;
+        printSummary = false;
         printSummary = false;
     }
 
@@ -68,27 +70,27 @@ public final class ValidateInterpretationTest {
 
     @Test(expected=NullPointerException.class)
     public void testConstructorNullExpectedFile() {
-        new ValidateInterpretation(null, observedFile, outputFile, resolution, printSummary);
+        new ValidateInterpretation(null, observedFile, HaploidBoolean, GlstringBoolean, outputFile, resolution, printSummary);
     }
 
     @Test(expected=NullPointerException.class)
     public void testConstructorNullObservedFile() {
-        new ValidateInterpretation(expectedFile, null, outputFile, resolution, printSummary);
+        new ValidateInterpretation(expectedFile, null, HaploidBoolean, GlstringBoolean, outputFile, resolution, printSummary);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testConstructorNullResolutionTooLow() {
-        new ValidateInterpretation(expectedFile, observedFile, outputFile, 0, printSummary);
+        new ValidateInterpretation(expectedFile, observedFile, HaploidBoolean, GlstringBoolean, outputFile, 0, printSummary);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testConstructorNullResolutionTooHigh() {
-        new ValidateInterpretation(expectedFile, observedFile, outputFile, 5, printSummary);
+        new ValidateInterpretation(expectedFile, observedFile, HaploidBoolean, GlstringBoolean, outputFile, 5, printSummary);
     }
 
     @Test
     public void testConstructor() {
-        assertNotNull(new ValidateInterpretation(expectedFile, observedFile, outputFile, resolution, printSummary));
+        assertNotNull(new ValidateInterpretation(expectedFile, observedFile, HaploidBoolean, GlstringBoolean, outputFile, resolution, printSummary));
     }
 
     @Test(expected=NullPointerException.class)


### PR DESCRIPTION
ngs-validate-interp now can accept HML files for the expected and observed files.