### PR TITLE
Split ngs-extract-expected into separate -glstrings and -haploids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
         <version>2.0.3</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.tinkerpop.blueprints</groupId>
         <artifactId>blueprints-core</artifactId>
         <version>2.6.0</version>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -78,6 +78,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -228,7 +233,15 @@
             <program>
               <id>ngs-extract-expected</id>
               <mainClass>org.nmdp.ngs.tools.ExtractExpected</mainClass>
-            </program>            
+            </program>
+            <program>
+              <id>ngs-extract-expected-glstrings</id>
+              <mainClass>org.nmdp.ngs.tools.ExtractExpectedGlstrings</mainClass>
+            </program>
+            <program>
+              <id>ngs-extract-expected-haploids</id>
+              <mainClass>org.nmdp.ngs.tools.ExtractExpectedHaploids</mainClass>
+            </program>
             <program>
               <id>ngs-filter-vcf</id>
               <mainClass>org.nmdp.ngs.tools.FilterVcf</mainClass>

--- a/tools/src/main/java/org/nmdp/ngs/tools/ExtractExpectedGlstrings.java
+++ b/tools/src/main/java/org/nmdp/ngs/tools/ExtractExpectedGlstrings.java
@@ -1,0 +1,181 @@
+/*
+
+    ngs-tools  Next generation sequencing (NGS/HTS) command line tools.
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.nmdp.ngs.tools;
+
+import static org.dishevelled.compress.Readers.reader;
+import static org.dishevelled.compress.Writers.writer;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import java.util.concurrent.Callable;
+
+import com.google.common.base.Splitter;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import org.dishevelled.commandline.ArgumentList;
+import org.dishevelled.commandline.CommandLine;
+import org.dishevelled.commandline.CommandLineParseException;
+import org.dishevelled.commandline.CommandLineParser;
+import org.dishevelled.commandline.Switch;
+import org.dishevelled.commandline.Usage;
+
+import org.dishevelled.commandline.argument.FileArgument;
+
+import org.nmdp.ngs.hml.HmlReader;
+
+import org.nmdp.ngs.hml.jaxb.Glstring;
+import org.nmdp.ngs.hml.jaxb.AlleleAssignment;
+import org.nmdp.ngs.hml.jaxb.Hml;
+import org.nmdp.ngs.hml.jaxb.Sample;
+import org.nmdp.ngs.hml.jaxb.Typing;
+
+/**
+ * Extract expected allele assignments in GL String format from a file in HML format.
+ */
+public final class ExtractExpectedGlstrings implements Callable<Integer> {
+    private final File inputHmlFile;
+    private final File outputFile;
+    private final OkHttpClient client = new OkHttpClient();
+    private static final String USAGE = "ngs-extract-expected-glstrings [args]";
+
+
+    /**
+     * Extract expected allele assignments in GL String format from a file in HML format.
+     *
+     * @param inputHmlFile input HML file, if any
+     * @param outputFile output interpretation file, if any
+     */
+    public ExtractExpectedGlstrings(final File inputHmlFile, final File outputFile) {
+        this.inputHmlFile = inputHmlFile;
+        this.outputFile = outputFile;
+    }
+
+
+    @Override
+    public Integer call() throws Exception {
+        BufferedReader reader = null;
+        PrintWriter writer = null;
+        try {
+            reader = reader(inputHmlFile);
+            writer = writer(outputFile);
+
+            Hml hml = HmlReader.read(reader);
+            for (Sample sample : hml.getSample()) {
+                String sampleId = sample.getId();
+                for (Typing typing : sample.getTyping()) {
+                    for (AlleleAssignment alleleAssignment : typing.getAlleleAssignment()) {
+                        for (Object child : alleleAssignment.getPropertyAndHaploidAndGenotypeList()) {
+                            if (child instanceof Glstring) {
+                                Glstring glstring = (Glstring) child;
+
+                                StringBuilder sb = new StringBuilder();
+                                sb.append(sampleId);
+                                sb.append("\t");
+                                // prefer uri if both are specified
+                                if (glstring.getUri() != null) {
+                                    sb.append(getGlstring(glstring.getUri()));
+                                }
+                                else if (glstring.getValue() != null) {
+                                    sb.append(glstring.getValue().replaceAll("\\s+",""));
+                                }
+                                writer.println(sb.toString());
+                            }
+                        }
+                    }
+                }
+            }
+            return 0;
+        }
+        finally {
+            try {
+                reader.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+            try {
+                writer.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    String getGlstring(final String uri) throws IOException {
+        Request request = new Request.Builder().url(uri).addHeader("Accept", "text/plain").build();
+        Response response = client.newCall(request).execute();
+        return response.body().string();        
+    }
+
+
+    /**
+     * Main.
+     *
+     * @param args command line args
+     */
+    public static void main(final String[] args) {
+        Switch about = new Switch("a", "about", "display about message");
+        Switch help = new Switch("h", "help", "display help message");
+        FileArgument inputHmlFile = new FileArgument("i", "input-hml-file", "input HML file, default stdin", false);
+        FileArgument outputFile = new FileArgument("o", "output-file", "output allele assignment file, default stdout", false);
+        
+        ArgumentList arguments = new ArgumentList(about, help, inputHmlFile, outputFile);
+        CommandLine commandLine = new CommandLine(args);
+
+        ExtractExpectedGlstrings extractExpectedGlstrings = null;
+        try
+        {
+            CommandLineParser.parse(commandLine, arguments);
+            if (about.wasFound()) {
+                About.about(System.out);
+                System.exit(0);
+            }
+            if (help.wasFound()) {
+                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                System.exit(0);
+            }
+            extractExpectedGlstrings = new ExtractExpectedGlstrings(inputHmlFile.getValue(), outputFile.getValue());
+        }
+        catch (CommandLineParseException | IllegalArgumentException e) {
+            Usage.usage(USAGE, e, commandLine, arguments, System.err);
+            System.exit(-1);
+        }
+        try {
+            System.exit(extractExpectedGlstrings.call());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/tools/src/main/java/org/nmdp/ngs/tools/ExtractExpectedHaploids.java
+++ b/tools/src/main/java/org/nmdp/ngs/tools/ExtractExpectedHaploids.java
@@ -1,0 +1,183 @@
+/*
+
+    ngs-tools  Next generation sequencing (NGS/HTS) command line tools.
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.nmdp.ngs.tools;
+
+import static org.dishevelled.compress.Readers.reader;
+import static org.dishevelled.compress.Writers.writer;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.PrintWriter;
+
+import java.util.List;
+
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+
+import org.dishevelled.commandline.ArgumentList;
+import org.dishevelled.commandline.CommandLine;
+import org.dishevelled.commandline.CommandLineParseException;
+import org.dishevelled.commandline.CommandLineParser;
+import org.dishevelled.commandline.Switch;
+import org.dishevelled.commandline.Usage;
+
+import org.dishevelled.commandline.argument.FileArgument;
+
+import org.nmdp.ngs.hml.HmlReader;
+
+import org.nmdp.ngs.hml.jaxb.Haploid;
+import org.nmdp.ngs.hml.jaxb.AlleleAssignment;
+import org.nmdp.ngs.hml.jaxb.Hml;
+import org.nmdp.ngs.hml.jaxb.Sample;
+import org.nmdp.ngs.hml.jaxb.Typing;
+
+/**
+ * Extract expected allele assignments in haploid elements from a file in HML format.
+ */
+public final class ExtractExpectedHaploids implements Callable<Integer> {
+    private final File inputHmlFile;
+    private final File outputFile;
+    private static final String USAGE = "ngs-extract-expected-haploids [args]";
+
+
+    /**
+     * Extract expected allele assignments in haploid elements from a file in HML format.
+     *
+     * @param inputHmlFile input HML file, if any
+     * @param outputFile output interpretation file, if any
+     */
+    public ExtractExpectedHaploids(final File inputHmlFile, final File outputFile) {
+        this.inputHmlFile = inputHmlFile;
+        this.outputFile = outputFile;
+    }
+
+
+    @Override
+    public Integer call() throws Exception {
+        BufferedReader reader = null;
+        PrintWriter writer = null;
+        try {
+            reader = reader(inputHmlFile);
+            writer = writer(outputFile);
+
+            Hml hml = HmlReader.read(reader);
+            for (Sample sample : hml.getSample()) {
+                String sampleId = sample.getId();
+                for (Typing typing : sample.getTyping()) {
+                    for (AlleleAssignment alleleAssignment : typing.getAlleleAssignment()) {
+                        ListMultimap<String, Haploid> haploidsByLocus = ArrayListMultimap.create();
+                        for (Object child : alleleAssignment.getPropertyAndHaploidAndGenotypeList()) {
+                            if (child instanceof Haploid) {
+                                Haploid haploid = (Haploid) child;
+                                haploidsByLocus.put(haploid.getLocus(), haploid);
+                            }
+                        }
+                        for (String locus : haploidsByLocus.keySet()) {
+                            List<Haploid> haploids = haploidsByLocus.get(locus);
+
+                            StringBuilder sb = new StringBuilder();
+                            sb.append(sampleId);
+                            sb.append("\t");
+                            // note only the first two haploids per locus are considered
+                            sb.append(toGenotype(haploids.get(0), haploids.size() > 1 ? haploids.get(1) : null));
+                            writer.println(sb.toString());
+                        }
+                    }
+                }
+            }
+            return 0;
+        }
+        finally {
+            try {
+                reader.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+            try {
+                writer.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    static String toGenotype(final Haploid haploid0, final Haploid haploid1) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(haploid0.getLocus());
+        sb.append("*");
+        sb.append(haploid0.getType());
+        if (haploid1 != null) {
+            sb.append("+");
+            sb.append(haploid1.getLocus());
+            sb.append("*");
+            sb.append(haploid1.getType());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Main.
+     *
+     * @param args command line args
+     */
+    public static void main(final String[] args) {
+        Switch about = new Switch("a", "about", "display about message");
+        Switch help = new Switch("h", "help", "display help message");
+        FileArgument inputHmlFile = new FileArgument("i", "input-hml-file", "input HML file, default stdin", false);
+        FileArgument outputFile = new FileArgument("o", "output-file", "output allele assignment file, default stdout", false);
+        
+        ArgumentList arguments = new ArgumentList(about, help, inputHmlFile, outputFile);
+        CommandLine commandLine = new CommandLine(args);
+
+        ExtractExpectedHaploids extractExpectedHaploids = null;
+        try
+        {
+            CommandLineParser.parse(commandLine, arguments);
+            if (about.wasFound()) {
+                About.about(System.out);
+                System.exit(0);
+            }
+            if (help.wasFound()) {
+                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                System.exit(0);
+            }
+            extractExpectedHaploids = new ExtractExpectedHaploids(inputHmlFile.getValue(), outputFile.getValue());
+        }
+        catch (CommandLineParseException | IllegalArgumentException e) {
+            Usage.usage(USAGE, e, commandLine, arguments, System.err);
+            System.exit(-1);
+        }
+        try {
+            System.exit(extractExpectedHaploids.call());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This pull request splits ```ngs-extract-expected``` into separate ```ngs-extract-expected-glstrings``` and ```ngs-extract-expected-haploids``` tools.  The code is different enough to merit separate callable classes and this eliminates the boolean flags.

Note that the output format is different:
```bash
$ ngs-extract-expected-haploids -i hml_1_0_1-example7-ngsFull.xml
$ ngs-extract-expected-glstrings -i hml_1_0_1-example7-ngsFull.xml 
1367-7150-8	  HLA-A*01:01:01+HLA-A*24:02:01
1367-7150-8	  HLA-B*08:01:01+HLA-B*57:01:01
1367-7150-8	  HLA-C*06:02:01+HLA-C*07:01:01
1367-7150-8	  HLA-DPB1*02:01:02+HLA-DPB1*04:01:01
1367-7150-8	  HLA-DQB1*02:01:01+HLA-DQB1*03:03:02
1367-7150-8	  HLA-DRB1*03:01:01+HLA-DRB1*07:01:01

$ ngs-extract-expected-haploids -i hml_1_0_1-example8-classI-ABC-ngs-sanger.xml 
1248-2396-4	  A*02:AAAUW+A*74:AB
1248-2396-4	  B*35:ACEHZ+B*57:VCXN
1248-2396-4	  C*04:ABHWU+C*06:ABJND
$ ngs-extract-expected-glstrings -i hml_1_0_1-example8-classI-ABC-ngs-sanger.xml
```
The first column is sample id and the second the genotype or better in GL String format.  Note that the ```<glstring>``` element in HML allows for GL resources to be specified at any level, up to multilocus unphased genotype.

```ngs-extract-expected-glstrings``` also now supports the ```<glstring uri="..."/>``` property.

This pull request does not remove the existing ExtractExpected class.  That could be in a follow on pull request to this one.